### PR TITLE
Tweak some Appendix A items

### DIFF
--- a/x-additional-material.md
+++ b/x-additional-material.md
@@ -94,11 +94,7 @@ using the above spells as a guideline for streamlining the entry.
 
 ### Unarmed Attacks
 
-When striking without a weapon (including strikes with just a gauntlet/brass knuckles), the character suffers a -4 to hit and deals 1 (+Str Bonus) points of damage. An unarmored Fighter or Thief can punch twice per round against a single target. 
-
-### War Magic
-
-In order to bridge the gap between dungeon and field combat, spell-casters of 10th level can gain access to War Magic as a class ability. This ability increases the range of spells by a factor of 4 (1” on the table equates to 20 feet). For more details on field combat, reference OED Book of War.
+When striking without a weapon (including strikes with just a gauntlet/brass knuckles), the character suffers a -4 to hit and deals 1 point of damage, plus half the Strength bonus.
 
 ### Fighter Feats (New)
 
@@ -106,7 +102,7 @@ In order to bridge the gap between dungeon and field combat, spell-casters of 10
 
 **Blind Fight**: You avoid penalties in melee combat against unseen opponents (invisibility, darkness, etc.). Note this does not allow spotting at a distance.
 
-**Pugilist**: You do not suffer a -4 to hit when making unarmed attacks, which now do 1d4 base damage. On an attack roll of 20, opponents must Save vs Death or be stunned (unable to move /act) for 1 round.
+**Pugilist**: You do not suffer a -4 to hit when making unarmed attacks, which now do 1d4 base damage, plus your full Strength bonus. On an attack roll of 20, opponents must Save vs Death or be stunned (unable to move/act) for 1 round.
 
 ## Clerics
 
@@ -157,7 +153,7 @@ A Familiar is a spirit that takes on the form of a small animal to provide magic
 
 **Saves**: As owner.
 
-**Languages**: Understands/Speaks Common + bonus languages, per Int score. Only the Magic User can 	understand the familiar. 
+**Languages**: Understands/Speaks Common + bonus languages, per Int score. Only the Magic User can understand the familiar. 
 When the familiar is present, it permits the Magic User to speak to animals of its kind and any other languages it knows. On addition, the Familiar adds its Intelligence Bonus to owner’s Learn Spells, Spell Research, and Magic Item Creation checks.
 
 ### Slime Splitting
@@ -175,18 +171,14 @@ Assume that slimes are roughly spherical, and their hit dice are proportional to
 
 ### Non-Proficiency
 
-**Using prohibited Armor**: Double encumbrance and halve bonus
-**Using prohibited Weapons**: -4 to hit and reduce damage die by 1 step
+**Using prohibited Armor**: Double encumbrance, halve bonus, negate any Thief or Wizard abilities.
+**Using prohibited Weapons**: -4 to hit and reduce damage die by 1 step.
 
 ### Helmets
 
-Alternatives rules for helmets, should tracking 1 in 6 attacks prove difficult at the table.
+Alternatives rules for helmets, in case the save vs. criticals is undesirable:
 
 **Helmets**: For each armor type, the listed AC assumes the use of a helmet.  If a helmet is not worn, then a 1 point penalty to AC is applied.
-
-### Wizard Staff
-
-The Judge may choose to allow a Staff to attack from the second rank (permitting a wizard who is out of spells to participate more safely in combat).
 
 ### Upkeep Costs ###
 Should calculating and tracking 1% of XP prove troublesome, you can instead opt charge at level up, as a form of deferred upkeep.  This charge is equal to 5% of the XP needed for the level, in Silver.  Ex: 100 SP to become a 2nd level Fighter,  480 SP to become an 5th level Thief, 5,000 to become a 9th level Wizard, etc.

--- a/x-additional-material.md
+++ b/x-additional-material.md
@@ -92,9 +92,13 @@ using the above spells as a guideline for streamlining the entry.
 
 ## Class Abilities
 
+### Subdual Attacks
+
+Blunt, wooden weapons can optionally be used to attack for nonlethal damage (knockout at 0 hit points); damage from critical hits becomes lethal (regardless of user intent).
+
 ### Unarmed Attacks
 
-When striking without a weapon (including strikes with just a gauntlet/brass knuckles), the character suffers a -4 to hit and deals 1 point of damage, plus half the Strength bonus.
+When striking without a weapon (including strikes with just a gauntlet/brass knuckles), the character suffers a -4 to hit and deals 1 point of damage, plus half the Strength bonus, as a subdual attack.
 
 ### Fighter Feats (New)
 
@@ -244,36 +248,33 @@ Should a creature find themselves immersed in a new language (and have no spare 
 
 ## Tournaments and Contests
 
+### Jousting
+
+In a proper tournament joust, riders must wear plate armor and shield
+with no enchantments. They make use of blunted lances (subdual damage).
+
+Each ride, the participants roll their standard melee attack. On a hit,
+the target must save vs stone. If the save is successful, the attacker's
+lance breaks. If the save fails, the target is unhorsed. 
+Participants take rides until one is unhorsed.
+
+### Melee
+
+Up to 50 participants per side line up across a field in equal armor, 
+no enchantments, and blunt clubs (subdual damage). Melee proceeds as normal;
+the event ends when one side is entirely down or surrenders. 
+This can also be resolved quickly using Book of War.
+
 ### Archery
 
 Each participant gets to take 6 shots at a dish sized target 30 feet
 away backed by an earthen "butt". The target itself is AC 10, and some
 targets will have inner rings of AC 5 and AC 0. Each hit on the target
 scores 1 point. Inner rings are worth 2 or 3 points respectively. A
-critical failure misses the butt entirely and may result in penalties.
+critical failure misses the butt entirely.
 
 In head-to-head competition, participants alternate shots. On a critical
 hit, there is a 1 in 6 chance to strike and split the opponent's arrow.
-
-### Jousting (Simplified)
-
-In a proper tournament joust, riders must wear plate armor and shield
-with no enchantments. They make use of blunted lances (no double damage
-from a charging mount). Participants take rides until one is unhorsed,
-or breaks three lances.
-
-Each ride, the participants roll their standard melee attack. On a hit,
-the target must save vs stone. If the save is successful, the attacker's
-lance breaks. If the save fails, the target is unhorsed. If the save is
-a critical failure, the target also takes lance damage.
-
-### Melee Rumble
-
-Up to 50 participants per side line up across a field in equal armor,
-blunt clubs, and no enchantments. Melee proceeds as normal, but the
-damage is non-lethal (0 HP only results in a Knock out). The event ends
-when one side is entirely down or surrenders. This can also be resolved
-quickly using Book of War.
 
 ## War Machine, Book of
 


### PR DESCRIPTION
- Add subdual damage rule -- referenced by unarmed attacks, jousting, and melee.
- Tweak unarmed attacks (& pugilist)
- Cut War Magic option & Wizard Staff from 2nd row